### PR TITLE
fix: classes, styles and artisan command

### DIFF
--- a/artisan
+++ b/artisan
@@ -111,7 +111,12 @@ function seed($pdo)
         }
 
         // Seed course data
-        $courses = ['Mathematics', 'Computer Science', 'Physics'];
+        $courses = [
+            'Bachelor of Science in Information Technology (BSIT)',
+            'Bachelor of Science in Computer Science (BSCS)',
+            'Bachelor of Science in Computer Engineering (BSCoE)',
+            'Bachelor of Science in Information Science (BSIS)'
+        ];
         $stmt = $pdo->prepare("INSERT INTO courses (course_name) VALUES (?)");
         foreach ($courses as $course) {
             $stmt->execute([$course]);
@@ -126,13 +131,22 @@ function seed($pdo)
 
         // Seed student data
         $students = [
-            ['Alice', 'alice@example.com', $courseMap['Mathematics']],
-            ['Bob', 'bob@example.com', $courseMap['Computer Science']],
-            ['Charlie', 'charlie@example.com', $courseMap['Mathematics']],
-            ['Dana', 'dana@example.com', null], // no course assigned
-            ['Eve', 'eve@example.com', $courseMap['Physics']],
+            ['Abainza, Rendel', 'rendel.abainza@example.com', $courseMap['Bachelor of Science in Information Technology (BSIT)']],
+            ['De Dios, Wendel', 'wendel.dedios@example.com', $courseMap['Bachelor of Science in Computer Science (BSCS)']],
+            ['Gontinias, Caira', 'caira.gontinias@example.com', $courseMap['Bachelor of Science in Computer Engineering (BSCoE)']],
+            ['Montinola, Diane', 'diane.montinola@example.com', $courseMap['Bachelor of Science in Information Science (BSIS)']],
+            ['Viado, John Paul', 'johnpaul.viado@example.com', null],
+            ['Santos, Maria', 'maria.santos@example.com', $courseMap['Bachelor of Science in Computer Science (BSCS)']],
+            ['Lopez, Juan', 'juan.lopez@example.com', null],
+            ['Reyes, Ana', 'ana.reyes@example.com', $courseMap['Bachelor of Science in Information Science (BSIS)']],
+            ['Cruz, Miguel', 'miguel.cruz@example.com', $courseMap['Bachelor of Science in Information Technology (BSIT)']],
+            ['Garcia, Carla', 'carla.garcia@example.com', $courseMap['Bachelor of Science in Computer Science (BSCS)']],
+            ['Ramos, Liza', 'liza.ramos@example.com', $courseMap['Bachelor of Science in Information Technology (BSIT)']],
+            ['Fernandez, Paolo', 'paolo.fernandez@example.com', null], // no course assigned
+            ['Torres, Bea', 'bea.torres@example.com', $courseMap['Bachelor of Science in Computer Engineering (BSCoE)']],
+            ['Navarro, Kim', 'kim.navarro@example.com', null],
+            ['Morales, Daniel', 'daniel.morales@example.com', $courseMap['Bachelor of Science in Computer Science (BSCS)']],
         ];
-
         $stmt = $pdo->prepare("INSERT INTO students (name, email, course_id) VALUES (?, ?, ?)");
         foreach ($students as $student) {
             $stmt->execute($student);

--- a/public/courses.php
+++ b/public/courses.php
@@ -73,7 +73,7 @@ $courses = $stmt->fetchAll();
                                 aria-labelledby="dropdownMenuIconButton-<?= $course['id'] ?>">
                                 <li>
                                     <a href="update_course.php?id=<?= urlencode($course['id']) ?>"
-                                        class="block px-4 py-2 hover:bg-gray-100 flex items-center gap-2">
+                                        class="px-4 py-2 hover:bg-gray-100 flex items-center gap-2">
                                         <i class="ti ti-edit"></i> Update Course
                                     </a>
                                 </li>
@@ -88,7 +88,7 @@ $courses = $stmt->fetchAll();
                         </div>
                     </div>
                     <div class="flex-1 p-6 flex flex-col">
-                        <h2 class="text-xl font-extrabold text-gray-800 mb-2">
+                        <h2 class="text-xl text-center font-extrabold text-gray-800 mb-2">
                             <?= htmlspecialchars($course['course_name']) ?>
                         </h2>
                         <?php if (!empty($course['description'])): ?>
@@ -108,7 +108,7 @@ $courses = $stmt->fetchAll();
     </div>
 
     <!-- Delete Confirmation Modal -->
-    <div id="delete-confirmation-modal" tabindex="-1" class="hidden fixed inset-0 z-50 flex items-center justify-center"
+    <div id="delete-confirmation-modal" tabindex="-1" class="hidden fixed inset-0 z-50 items-center justify-center"
         style="background-color: rgba(0, 0, 0, 0.5);">
         <div class="bg-white rounded-lg shadow p-6 w-full max-w-sm">
             <h2 class="text-lg font-semibold mb-2">Confirm Deletion</h2>
@@ -132,6 +132,7 @@ $courses = $stmt->fetchAll();
         deleteLinks.forEach(link => {
             link.addEventListener('click', function (e) {
                 e.preventDefault();
+                modal.classList.add('flex');
                 const courseId = this.getAttribute('data-id');
                 confirmDeleteBtn.href = `delete_course.php?id=${courseId}`;
                 modal.classList.remove('hidden');

--- a/public/view_course.php
+++ b/public/view_course.php
@@ -151,8 +151,7 @@ $students = $stmt->fetchAll();
         </div>
     </div>
     <!-- Unenroll Confirmation Modal -->
-    <div id="unenroll-confirmation-modal" tabindex="-1"
-        class="hidden fixed inset-0 z-50 flex items-center justify-center"
+    <div id="unenroll-confirmation-modal" tabindex="-1" class="hidden fixed inset-0 z-50 items-center justify-center"
         style="background-color: rgba(0, 0, 0, 0.5);">
         <div class="bg-white rounded-lg shadow p-6 w-full max-w-sm">
             <h2 class="text-lg font-semibold mb-2">Confirm Unenroll</h2>
@@ -184,6 +183,7 @@ $students = $stmt->fetchAll();
         unenrollLinks.forEach(link => {
             link.addEventListener('click', function (e) {
                 e.preventDefault();
+                modal.classList.add('flex');
                 const studentId = this.getAttribute('data-id');
                 confirmUnenrollBtn.href = `unenroll_student.php?id=${studentId}&course_id=<?= urlencode($courseId) ?>`;
                 modal.classList.remove('hidden');


### PR DESCRIPTION
## Description

- Remove warnings from tailwind extension such as two display in a class
- Centered the Course name in `courses.php`
- Add more students and courses in our `artisan` cli

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/568099b8-a0b6-4327-8916-32a418f82ac9)


